### PR TITLE
[Change]: ブログページに直接飛ぶ

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -1,6 +1,0 @@
-<h1>ブログ</h1>
-下のボタンをクリックするとブログに飛びます！<br>
-<a href="https://linuxcodevserver.github.io/linuxcodevblog"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Go_Logo_Blue.svg/215px-Go_Logo_Blue.svg.png"></a><br>
-...なーんかこのボタン見覚えがあるなー
-<br><br><br><br><br><br><br>
-<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">皆の意見交流所公式サイト</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://discord.com/invite/sUdAE64Zc7" property="cc:attributionName" rel="cc:attributionURL">Zect#3279, okaits#7534(皆の意見交流所)</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,4 +27,4 @@ nav:
     - ホーム: index.md
     - プロジェクト一覧: projects.md
     - 寄付: donate.md
-    - ブログ: blog.md
+    - ブログ: https://linuxcodevserver.github.io/linuxcodevblog/


### PR DESCRIPTION
- ブログのnavのpathを "https://linuxcodevserver.github.io/linuxcodevblog/" に変更
- それに伴い、要らなくなった "blog.md" の削除